### PR TITLE
Add error code to exception response in ApiServer.

### DIFF
--- a/src/ApiServer.php
+++ b/src/ApiServer.php
@@ -139,6 +139,7 @@ abstract class ApiServer
         $err = new class(){};
 
         $err->error = $e->getMessage();
+        $err->code = $e->getCode();
 
         $r = new DummyJsonResponse(500);
         try {


### PR DESCRIPTION
This will allow application level error codes to be returned.